### PR TITLE
Change bower dependencies installation path

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-    "directory": "dist/vendor"
+    "directory": "docs/vendor"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 *.log
 npm-debug.log*
-
-# Dependencies
 node_modules
-dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.log
 npm-debug.log*
+
+# Dependencies
 node_modules
+dist


### PR DESCRIPTION
# Description

The bower dependencies were not being ignored by Git

# Change made

`dist` was added as a file to ignore in `.gitignore`
